### PR TITLE
Fix config file name

### DIFF
--- a/app/Support/ConfigRepository.php
+++ b/app/Support/ConfigRepository.php
@@ -14,7 +14,7 @@ class ConfigRepository
 
     public function __construct()
     {
-        $path = "{$this->findHomeDirectory()}/.actions-watcher.json}";
+        $path = "{$this->findHomeDirectory()}/.actions-watcher.json";
 
         $this->valuestore = Valuestore::make($path);
     }


### PR DESCRIPTION
There is currently an `}` appended to the end of the config file name, like this: `.actions-watcher.json}`

This removes this `}`. 